### PR TITLE
Ajustar duración de intro y visualización de porcentaje de carga

### DIFF
--- a/assets/css/splash.css
+++ b/assets/css/splash.css
@@ -70,8 +70,8 @@
     background-color: #222;
     border-radius: 0px !important; /* Forzar bordes cuadrados */
     overflow: hidden;
-    margin-top: 70px; /* Aún más abajo */
-    margin-bottom: 40px; /* Mayor separación inferior para el porcentaje si se mueve debajo */
+    margin-top: 100px; /* Aumentado para bajarlo más */
+    margin-bottom: 40px;
     opacity: 0; /* Controlado por JS */
     position: relative;
     transition: opacity 0.5s ease-out; /* Para aparición suave desde JS */

--- a/assets/js/splash-logic.js
+++ b/assets/js/splash-logic.js
@@ -18,7 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let progress = 0;
     const intervalTime = 30;
-    const totalDuration = 11000; // Duración total de la barra de progreso
+    const totalDuration = 9000; // Reducida a 9000ms (11000 - 2000)
     const progressIncrement = (intervalTime / totalDuration) * 100;
 
     // Estilos iniciales para la transición de inmersión del contenido principal


### PR DESCRIPTION
- Reducida la duración de la animación de la barra de progreso en 2 segundos.
- Reposicionada la barra de progreso más abajo en la pantalla.
- Verificada y asegurada la lógica para la actualización dinámica y visualización correcta del porcentaje de carga (X%) al costado de la barra de progreso.
- Mantenidos los ajustes previos en animación de escritura de textos, partículas y transición de inmersión.