### PR TITLE
Ajustar duración de intro, depurar contador de scroll y refinar header

### DIFF
--- a/assets/js/project-scroll-counter.js
+++ b/assets/js/project-scroll-counter.js
@@ -1,8 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
     const mediaGallery = document.querySelector('.project-media-scroll-gallery');
     const currentIndexSpan = document.getElementById('media-current-index');
-    const totalCountSpan = document.getElementById('media-total-count'); // Este span contendrá el número total
-    const scrollMediaCounterElement = document.getElementById('scroll-media-counter'); // El div contenedor completo
+    const totalCountSpan = document.getElementById('media-total-count');
+    const scrollMediaCounterElement = document.getElementById('scroll-media-counter');
+
+    // DEBUG: Verificar selección de elementos
+    console.log('scrollMediaCounterElement:', scrollMediaCounterElement);
+    console.log('mediaGallery:', mediaGallery);
+    console.log('currentIndexSpan:', currentIndexSpan);
+    console.log('totalCountSpan:', totalCountSpan);
 
     if (!mediaGallery || !currentIndexSpan || !totalCountSpan || !scrollMediaCounterElement) {
         if (scrollMediaCounterElement) {
@@ -14,57 +20,72 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const mediaElements = Array.from(mediaGallery.querySelectorAll('img, .video-placeholder-container'));
     const totalMedia = mediaElements.length;
+    console.log('mediaElements count:', mediaElements.length); // DEBUG
 
     if (totalMedia === 0) {
         scrollMediaCounterElement.style.display = 'none';
         return;
     }
 
-    // Establecer el texto completo una vez, luego solo actualizar el número actual
-    totalCountSpan.textContent = totalMedia; // Solo el número total
-    currentIndexSpan.textContent = '1'; // Iniciar en 1
-
+    totalCountSpan.textContent = totalMedia;
+    currentIndexSpan.textContent = '1';
 
     function updateScrollCounter() {
-        let mostVisibleElementIndex = 0;
-        let maxVisibility = 0;
+        console.log('updateScrollCounter triggered by scroll'); // DEBUG
+        let mostVisibleElementIndex = -1; // Iniciar con -1 para saber si se encontró alguno
+        let minDistanceToCenter = Infinity; // Usaremos la menor distancia al centro
+
         const windowHeight = window.innerHeight;
-        const viewportCenter = windowHeight / 2;
+        const viewportCenterY = windowHeight / 2;
 
         mediaElements.forEach((el, index) => {
             const rect = el.getBoundingClientRect();
 
             // Considerar solo elementos que están al menos parcialmente en el viewport
-            if (rect.bottom < 0 || rect.top > windowHeight) {
+            // O un poco fuera, para detectar el que está "a punto de entrar" o "acaba de salir"
+            if (rect.bottom < -50 || rect.top > windowHeight + 50) { // Añadido un pequeño umbral
+                // console.log(`Media ${index}: Fuera de viewport (top: ${rect.top}, bottom: ${rect.bottom})`); // DEBUG
                 return;
             }
 
-            // Calcular el punto medio vertical del elemento
-            const elementMidPoint = rect.top + rect.height / 2;
-            // Calcular la distancia del punto medio del elemento al centro del viewport
-            const distanceToCenter = Math.abs(elementMidPoint - viewportCenter);
+            const elementMidPointY = rect.top + rect.height / 2;
+            const distanceToCenter = Math.abs(elementMidPointY - viewportCenterY);
 
-            // Una forma de priorizar: el que esté más cerca del centro del viewport.
-            // Se puede ajustar la lógica si se prefiere el que tiene más área visible.
-            // Por ahora, nos quedaremos con el que esté más cerca del centro.
+            // DEBUG: Loguear info de cada elemento evaluado
+            // console.log(`Media ${index}: top=${rect.top.toFixed(0)}, midY=${elementMidPointY.toFixed(0)}, distToCenter=${distanceToCenter.toFixed(0)}`);
 
-            // Inicializar si es el primer elemento evaluado en este ciclo de scroll
-            if (index === 0 || distanceToCenter < maxVisibility) {
-                maxVisibility = distanceToCenter; // Aquí maxVisibility representa la menor distancia al centro
+            if (distanceToCenter < minDistanceToCenter) {
+                minDistanceToCenter = distanceToCenter;
                 mostVisibleElementIndex = index;
             }
         });
 
-        // Si se detectó algún elemento (maxVisibility habrá sido actualizado desde un valor alto inicial)
-        // O si se prefiere la lógica anterior de porcentaje de visibilidad:
-        // const visibleHeight = Math.max(0, Math.min(rect.bottom, windowHeight) - Math.max(rect.top, 0));
-        // const visibilityPercentage = visibleHeight / rect.height;
-        // if (visibilityPercentage > maxVisibility) { ... }
+        console.log('Most visible element index:', mostVisibleElementIndex, 'Min distance to center:', minDistanceToCenter.toFixed(0)); // DEBUG
 
-        // Actualizamos el contador con el índice del elemento más cercano al centro
-        currentIndexSpan.textContent = mostVisibleElementIndex + 1;
+        if (mostVisibleElementIndex !== -1) {
+            const newIndexText = String(mostVisibleElementIndex + 1);
+            if (currentIndexSpan.textContent !== newIndexText) {
+                console.log('Attempting to update currentIndexSpan.textContent to:', newIndexText); // DEBUG
+                currentIndexSpan.textContent = newIndexText;
+                console.log('textContent después de actualizar:', currentIndexSpan.textContent); // DEBUG
+            }
+        } else {
+            // Si ningún elemento se considera "más visible" (ej. durante scroll muy rápido o si la galería está fuera de vista)
+            // podríamos optar por no actualizar o volver al primero/último si es el caso.
+            // Por ahora, si no se encuentra ninguno, el contador no se actualiza desde el último valor válido.
+            console.log('No se encontró un elemento predominantemente visible para actualizar el contador.'); //DEBUG
+        }
     }
 
-    updateScrollCounter(); // Llamada inicial
-    window.addEventListener('scroll', updateScrollCounter, { passive: true });
+    // Throttle/Debounce para el evento de scroll para no sobrecargar el navegador
+    let scrollTimeout;
+    window.addEventListener('scroll', () => {
+        if (scrollTimeout) {
+            clearTimeout(scrollTimeout);
+        }
+        scrollTimeout = setTimeout(updateScrollCounter, 50); // Ajustar delay según necesidad (50-100ms es usual)
+    }, { passive: true });
+
+    // Llamada inicial para establecer el contador correctamente
+    setTimeout(updateScrollCounter, 100); // Pequeño delay para asegurar que el layout esté estable
 });


### PR DESCRIPTION
- Reducida la duración de la barra de progreso de la splash screen a 5 segundos.
- Ajustado el CSS del header en las páginas de detalle para mayor altura y mejor alineación del logo y enlace "Back to Projects".
- Cambiado el formato del texto del contador de scroll en páginas de detalle a "X foto de Y".
- Añadidos console.log exhaustivos en `assets/js/project-scroll-counter.js` para facilitar la depuración por parte del usuario de por qué el contador podría no estar actualizándose visualmente.
- Verificada y mantenida la lógica para la funcionalidad del contador y demás animaciones.