### PR TITLE
Ajustar duración intro, depurar contador scroll y revisar header fijo

### DIFF
--- a/assets/js/project-scroll-counter.js
+++ b/assets/js/project-scroll-counter.js
@@ -5,22 +5,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const scrollMediaCounterElement = document.getElementById('scroll-media-counter');
 
     // DEBUG: Verificar selección de elementos
-    console.log('scrollMediaCounterElement:', scrollMediaCounterElement);
-    console.log('mediaGallery:', mediaGallery);
-    console.log('currentIndexSpan:', currentIndexSpan);
-    console.log('totalCountSpan:', totalCountSpan);
+    console.log('Contador Scroll - Elemento scrollMediaCounterElement:', scrollMediaCounterElement);
+    console.log('Contador Scroll - Elemento mediaGallery:', mediaGallery);
+    console.log('Contador Scroll - Elemento currentIndexSpan:', currentIndexSpan);
+    console.log('Contador Scroll - Elemento totalCountSpan:', totalCountSpan);
 
     if (!mediaGallery || !currentIndexSpan || !totalCountSpan || !scrollMediaCounterElement) {
         if (scrollMediaCounterElement) {
             scrollMediaCounterElement.style.display = 'none';
         }
-        console.warn('Elementos para el contador de scroll no encontrados. El contador no funcionará.');
+        console.warn('Contador Scroll - Elementos no encontrados. El contador no funcionará.');
         return;
     }
 
     const mediaElements = Array.from(mediaGallery.querySelectorAll('img, .video-placeholder-container'));
     const totalMedia = mediaElements.length;
-    console.log('mediaElements count:', mediaElements.length); // DEBUG
+    console.log('Contador Scroll - mediaElements count:', mediaElements.length); // DEBUG
 
     if (totalMedia === 0) {
         scrollMediaCounterElement.style.display = 'none';
@@ -30,62 +30,53 @@ document.addEventListener('DOMContentLoaded', () => {
     totalCountSpan.textContent = totalMedia;
     currentIndexSpan.textContent = '1';
 
-    function updateScrollCounter() {
-        console.log('updateScrollCounter triggered by scroll'); // DEBUG
-        let mostVisibleElementIndex = -1; // Iniciar con -1 para saber si se encontró alguno
-        let minDistanceToCenter = Infinity; // Usaremos la menor distancia al centro
-
+    function updateScrollCounterSimplified() {
+        console.log('Contador Scroll - updateScrollCounterSimplified triggered'); // DEBUG
+        let elementInViewIndex = 0; // Default to 0 (index for 1st item)
         const windowHeight = window.innerHeight;
-        const viewportCenterY = windowHeight / 2;
+        // Punto de activación: considera un elemento "actual" si su parte superior
+        // ha pasado el 30% superior de la ventana, pero aún no ha salido completamente por arriba.
+        const activationPoint = windowHeight * 0.3;
 
-        mediaElements.forEach((el, index) => {
+        for (let i = 0; i < mediaElements.length; i++) {
+            const el = mediaElements[i];
             const rect = el.getBoundingClientRect();
 
-            // Considerar solo elementos que están al menos parcialmente en el viewport
-            // O un poco fuera, para detectar el que está "a punto de entrar" o "acaba de salir"
-            if (rect.bottom < -50 || rect.top > windowHeight + 50) { // Añadido un pequeño umbral
-                // console.log(`Media ${index}: Fuera de viewport (top: ${rect.top}, bottom: ${rect.bottom})`); // DEBUG
-                return;
+            // console.log(`Media ${i}: top: ${rect.top}, bottom: ${rect.bottom}, height: ${rect.height}`); // DEBUG
+
+            // Si la parte superior del elemento está por encima del punto de activación
+            // Y la parte inferior del elemento está por debajo del punto de activación (o sea, el punto está DENTRO del elemento)
+            // O si la parte superior del elemento está visible y es el último elemento (para asegurar que el último se marque)
+            if (rect.top <= activationPoint && rect.bottom >= activationPoint) {
+                elementInViewIndex = i;
+                break; // Encontramos el primero que cumple, es el actual
             }
-
-            const elementMidPointY = rect.top + rect.height / 2;
-            const distanceToCenter = Math.abs(elementMidPointY - viewportCenterY);
-
-            // DEBUG: Loguear info de cada elemento evaluado
-            // console.log(`Media ${index}: top=${rect.top.toFixed(0)}, midY=${elementMidPointY.toFixed(0)}, distToCenter=${distanceToCenter.toFixed(0)}`);
-
-            if (distanceToCenter < minDistanceToCenter) {
-                minDistanceToCenter = distanceToCenter;
-                mostVisibleElementIndex = index;
+            // Si estamos al final y el último elemento está parcialmente visible desde abajo
+            if (i === mediaElements.length -1 && rect.top < windowHeight && rect.bottom >=0) {
+                 elementInViewIndex = i;
             }
-        });
+        }
 
-        console.log('Most visible element index:', mostVisibleElementIndex, 'Min distance to center:', minDistanceToCenter.toFixed(0)); // DEBUG
+        console.log('Contador Scroll - Índice simplificado detectado:', elementInViewIndex);
 
-        if (mostVisibleElementIndex !== -1) {
-            const newIndexText = String(mostVisibleElementIndex + 1);
+        if (currentIndexSpan) { // Doble chequeo por si acaso
+            const newIndexText = String(elementInViewIndex + 1);
             if (currentIndexSpan.textContent !== newIndexText) {
-                console.log('Attempting to update currentIndexSpan.textContent to:', newIndexText); // DEBUG
+                console.log('Contador Scroll - ACTUALIZANDO contador a:', newIndexText);
                 currentIndexSpan.textContent = newIndexText;
-                console.log('textContent después de actualizar:', currentIndexSpan.textContent); // DEBUG
             }
-        } else {
-            // Si ningún elemento se considera "más visible" (ej. durante scroll muy rápido o si la galería está fuera de vista)
-            // podríamos optar por no actualizar o volver al primero/último si es el caso.
-            // Por ahora, si no se encuentra ninguno, el contador no se actualiza desde el último valor válido.
-            console.log('No se encontró un elemento predominantemente visible para actualizar el contador.'); //DEBUG
         }
     }
 
-    // Throttle/Debounce para el evento de scroll para no sobrecargar el navegador
     let scrollTimeout;
     window.addEventListener('scroll', () => {
+        // console.log('Scroll event fired'); // DEBUG - Muy verboso, usar con cuidado
         if (scrollTimeout) {
             clearTimeout(scrollTimeout);
         }
-        scrollTimeout = setTimeout(updateScrollCounter, 50); // Ajustar delay según necesidad (50-100ms es usual)
+        scrollTimeout = setTimeout(updateScrollCounterSimplified, 60); // Ajustado a 60ms
     }, { passive: true });
 
     // Llamada inicial para establecer el contador correctamente
-    setTimeout(updateScrollCounter, 100); // Pequeño delay para asegurar que el layout esté estable
+    setTimeout(updateScrollCounterSimplified, 150); // Pequeño delay para asegurar que el layout esté estable
 });


### PR DESCRIPTION
- Reducida duración de la barra de progreso en splash screen a 5s.
- Ajustado CSS del header en páginas de detalle para mayor altura.
- Revisada y simplificada lógica en project-scroll-counter.js para el contador dinámico "X foto de Y".
- Añadidos console.logs exhaustivos en project-scroll-counter.js para facilitar depuración de la actualización del contador por el usuario.
- Verificados estilos para posicionamiento fijo del header y contador.